### PR TITLE
How to avoid updates: End the release table updates starting with 1.8.0.

### DIFF
--- a/pywbem/installation.html
+++ b/pywbem/installation.html
@@ -30,6 +30,14 @@
 
 <p>The following distribution archives are available for download:</p>
 
+<p>Note: Only versions up to 1.7.x are documented in the following table. Starting withversion 1.8.0,
+the versions are no longer documented here. Please look up new versions on one of:</p>
+
+<ul>
+<li><a href="https://pypi.python.org/pypi/pywbem">pywbem on PyPI</a></li>
+<li><a href="https://github.com/pywbem/pywbem/releases">pywbem releases on GitHub</a></li>
+</ul> 
+
 <a name="table1"></a>
 <table border="1" style="width:100%">
   <tr>


### PR DESCRIPTION
Addresses a part of https://github.com/pywbem/pywbem/issues/3197

This is a less radical approach, by keeping the release table and install instructions, and just adding a reference to Pypi and github for releases starting with 1.8.0.